### PR TITLE
Fix source distros to work with Linux.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+recursive-include _heapprof *.h *.cc

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,5 +3,5 @@
 ## 1.0
 
 * 1.0.0 (2019-08-12) Initial release.
-* 1.0.1 (2019-08-19) Add support for WIN64 (via binary wheels) and Linux (via source wheels,
+* 1.0.1 (2019-08-20) Add support for WIN64 (via binary wheels) and Linux (via source wheels,
     as the glibc requirements for ABSL don't allow use of manylinux)

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ cppmodule = Extension(
         "_heapprof/stats_gatherer.h",
         "_heapprof/util.h",
     ],
-    include_dirs=[".", "build/absl"],
+    include_dirs=[os.getcwd(), "build/absl"],
     library_dirs=["build\\absl\\absl\\base\\Debug" if WINDOWS else "build/absl/absl/base"],
     libraries=["absl_base"],
     define_macros=[("PY_SSIZE_T_CLEAN", None)],
@@ -107,7 +107,7 @@ cppmodule = Extension(
 setup(
     # About this project
     name="heapprof",
-    version="1.0.1a3",
+    version="1.0.1a5",
     description="Logging heap profiler",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ cppmodule = Extension(
 setup(
     # About this project
     name="heapprof",
-    version="1.0.1.a1",
+    version="1.0.1a2",
     description="Logging heap profiler",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -95,7 +95,7 @@ setup(
     python_requires=">=3.7",
     ext_modules=[cppmodule],
     packages=find_packages(exclude=["tests", "tools", "docs", "docs_src"]),
-    install_requires=["cmake"],
+    setup_requires=["cmake"],
     # Testing
     test_suite="nose.collector",
     tests_require=["nose"],

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ cppmodule = Extension(
 setup(
     # About this project
     name="heapprof",
-    version="1.0.1a5",
+    version="1.0.1",
     description="Logging heap profiler",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -116,7 +116,7 @@ setup(
     author_email="zunger@humu.com",
     license="MIT",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Linux distros didn't work in the previous cut because there is no such thing as a Linux wheel. manylinux (the standard meant to fill that niche) can't be used here, because heapprof depends on ABSL which depends on too high a version of glibc to make manylinux happy, so instead we handle Linux by providing a source distribution (for now) and maybe some specific binary wheels later.

Testing this by actually trying to deploy it to production with a binary on GCP, we quickly found some subtleties, especially because the compile step requires cmake to already be installed. This CL makes all that work by using setuptools `setup_requires` parameter to fetch the cmake egg before setup runs, and then doing some magic to find the actual path to `cmake` itself within that egg. Together with fixing the manifest, this creates a source distribution which correctly runs on Linux.

As a result, with this in place we should be able to cut 1.0.1 with OSX and Win64 wheels, and a source dist that runs correctly anywhere else that has reasonable compilers and glibc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humu/heapprof/22)
<!-- Reviewable:end -->
